### PR TITLE
Various cleanups and documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ be defined, which will be applied if none of the branches match.
 > with Emacs 24+
 
 
-## Example
+## Examples
+
+### Dispatch on value of first argument
 
 ```elisp
 (require 'multi)
@@ -38,6 +40,19 @@ be defined, which will be applied if none of the branches match.
 (area 'sphere 12) ;; => 'oops
 ```
 
+### Dispatch on current context (major mode)
+
+```elisp
+(defmulti my-mode ()
+  "Report current major mode."
+  major-mode)
+
+(defmulti-method my-mode 'emacs-lisp-mode ()
+  (message "Hi! An old fellow is here!"))
+
+(defmulti-method my-mode 'clojure-mode ()
+  (message "Welcome! A new lisp is here!"))
+```
 
 ## Installation
 

--- a/multi.el
+++ b/multi.el
@@ -51,7 +51,7 @@ multi-method.")
 (defvar multi/-method-fallbacks (make-hash-table)
   "A dictionary of fallbacks for each multi-method.
 
-Type: { Symbold → (A... → B) }
+Type: { Symbol → (A... → B) }
 
 This holds mappings of names to fallback method branches, which are
 invoked in case none of the premises for the defined branches match.")

--- a/multi.el
+++ b/multi.el
@@ -67,7 +67,7 @@ invoked in case none of the premises for the defined branches match.")
      (defun ,name (&rest args)
        ,(if (stringp docstring) docstring (prog1 nil (push docstring forms)))
        (apply (multi/-dispatch-with ',name (lambda ,arguments ,@forms))
-        args))
+              args))
      (multi/-make-multi-method ',name)))
 
 
@@ -76,7 +76,7 @@ invoked in case none of the premises for the defined branches match.")
   (declare (debug (&define name sexp (&rest arg) def-body))
            (indent defun))
   `(multi/-make-multi-method-branch ',name ,premise
-            (lambda ,arguments ,@forms)))
+                                    (lambda ,arguments ,@forms)))
 
 
 (defmacro defmulti-method-fallback (name arguments &rest forms)
@@ -100,12 +100,12 @@ for the branches in a multi-method match the dispatch value."
 ;;;; Helper functions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defun multi/-make-multi-method (name)
   (puthash name (make-hash-table :test 'equal)
-     multi/-method-branches))
+           multi/-method-branches))
 
 
 (defun multi/-make-multi-method-branch (name premise lambda)
   (puthash premise lambda
-     (gethash name multi/-method-branches)))
+           (gethash name multi/-method-branches)))
 
 
 (defun multi/-make-multi-method-fallback (name lambda)
@@ -115,18 +115,19 @@ for the branches in a multi-method match the dispatch value."
 (defun multi/-dispatch-with (name f)
   (lambda (&rest args)
     (let* ((premise (apply f args))
-     (method  (gethash premise (gethash name multi/-method-branches))))
+           (method  (gethash premise (gethash name multi/-method-branches))))
       (if method (apply method args)
-  (apply (gethash name multi/-method-fallbacks) args)))))
+        (apply (gethash name multi/-method-fallbacks) args)))))
 
 
 ;;;; Emacs stuff ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (eval-after-load "lisp-mode"
   '(progn
-     (font-lock-add-keywords 'emacs-lisp-mode
-                             '(("(\\(defmulti\\|defmulti-method\\|defmulti-method-fallback\\)\\(?:\\s-\\)+\\(\\_<.*?\\_>\\)"
-                                (1 font-lock-keyword-face)
-                                (2 font-lock-function-name-face))))))
+     (font-lock-add-keywords
+      'emacs-lisp-mode
+      '(("(\\(defmulti\\|defmulti-method\\|defmulti-method-fallback\\)\\(?:\\s-\\)+\\(\\_<.*?\\_>\\)"
+         (1 font-lock-keyword-face)
+         (2 font-lock-function-name-face))))))
 
 
 (provide 'multi)


### PR DESCRIPTION
Hi. Thanks for the nice package.

I have added some more docs as this paradigm might not be familiar to elispers. 

Would be also nice to remove redundant documentation from the readme. It's always confusing when the same thing is documented twice. In emacs pretty much everything is self documented and people are used to that.
